### PR TITLE
Two small fixes

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -6,6 +6,7 @@ import           Distribution.PackageDescription    (PackageDescription (..))
 import           Distribution.Simple
 import           Distribution.Simple.Install
 import           Distribution.Simple.LocalBuildInfo
+import           Distribution.Simple.Program
 import           Distribution.Simple.Setup
 import           Distribution.Simple.Utils
 import           System.FilePath
@@ -14,7 +15,8 @@ import           System.FilePath
 -- libexec directory.
 main :: IO ()
 main = defaultMainWithHooks $ simpleUserHooks
-    { copyHook = copyThings
+    { copyHook = copyThings,
+      hookedPrograms = [simpleProgram "git"]
     }
 
 -- | Copy "extra" executables to $PREFIX/libexec/git-vogue/ instead of

--- a/git-vogue.cabal
+++ b/git-vogue.cabal
@@ -106,5 +106,5 @@ test-suite unit
                      , hspec
                      , process
                      , temporary
-
+  build-tools:         git
 -- vim: set tabstop=21 expandtab:

--- a/git-vogue.cabal
+++ b/git-vogue.cabal
@@ -90,7 +90,7 @@ executable git-vogue-ghc-mod
   hs-source-dirs:      src
   main-is:             git-vogue-ghc-mod.hs
   build-depends:       base
-                     , ghc-mod         >= 5.2    && < 5.5
+                     , ghc-mod         >= 5.2    && < 5.6
                      , git-vogue
 
 test-suite unit

--- a/git-vogue.cabal
+++ b/git-vogue.cabal
@@ -83,7 +83,7 @@ executable git-vogue-stylish
                      , Diff
                      , git-vogue
                      , strict
-                     , stylish-haskell >= 0.5.11 && < 0.6
+                     , stylish-haskell >= 0.5.16 && < 0.6
 
 executable git-vogue-ghc-mod
   default-language:    Haskell2010

--- a/src/git-vogue-stylish.hs
+++ b/src/git-vogue-stylish.hs
@@ -62,7 +62,9 @@ getConfig
 getConfig =
     -- Don't spew every file checked to stdout
     let v = makeVerbose False
-    in configFilePath v Nothing >>= loadConfig v
+    in do
+       config <- configFilePath v Nothing
+       loadConfig v (Just config)
 
 -- | Checks whether running Stylish over a given file produces any differences.
 -- Returns TRUE if there's nothing left to change.


### PR DESCRIPTION
On simply loosens the ghc-mod dependency---the newer version compiles just fine.

The other change accommodates an interface change from stylish-haskell's newest version.
